### PR TITLE
Reverting pattern center calibration to not use lazy loading.

### DIFF
--- a/requirements_WINDOWS.txt
+++ b/requirements_WINDOWS.txt
@@ -91,7 +91,7 @@ pyebsdindex==0.1.1
 pyflakes==2.5.0
 Pygments==2.13.0
 pyinstaller @ https://github.com/pyinstaller/pyinstaller/archive/develop.zip
-pyinstaller-hooks-contrib==2022.13
+pyinstaller-hooks-contrib==2023.2
 pylint==2.15.5
 pyopencl==2022.3.1
 pyparsing==3.0.9

--- a/requirements_macOS_x86_64.txt
+++ b/requirements_macOS_x86_64.txt
@@ -76,7 +76,7 @@ PyCifRW==4.4.5
 pyebsdindex==0.1.1
 Pygments==2.14.0
 pyinstaller==5.9.0
-pyinstaller-hooks-contrib==2023.0
+pyinstaller-hooks-contrib==2023.2
 pyopencl==2022.3.1
 pyparsing==3.0.9
 PySide6==6.3.2

--- a/scripts/hough_indexing.py
+++ b/scripts/hough_indexing.py
@@ -110,6 +110,11 @@ class HiSetupDialog(QDialog):
             path.join(self.working_dir, "project_settings.txt")
         )
         self.program_settings = SettingFile("advanced_settings.txt")
+        try:
+            lazy = eval(self.program_settings.read("Lazy Loading"))
+        except:
+            lazy = False
+        self.ui.checkBoxLazy.setChecked(lazy)
 
         try:
             self.convention = self.setting_file.read("Convention")

--- a/scripts/pattern_center.py
+++ b/scripts/pattern_center.py
@@ -91,7 +91,7 @@ class PatterCenterDialog(QDialog):
             try:
                 mp_path = self.setting_file.read(f"Master pattern {i}")
                 try:
-                    mp = kp.load(mp_path, lazy=True)
+                    mp = kp.load(mp_path)
                 except Exception as e:
                     print(e.with_traceback(None))
                     continue
@@ -127,7 +127,7 @@ class PatterCenterDialog(QDialog):
 
     def setupCalibrationPatterns(self):
         self.pattern_index = 0
-        self.s_cal = kp.load(self.setting_path, lazy=True)
+        self.s_cal = kp.load(self.setting_path)
         sig_shape = self.s_cal.axes_manager.signal_shape[::-1]
         self.nav_size = self.s_cal.axes_manager.navigation_size
 
@@ -231,7 +231,7 @@ class PatterCenterDialog(QDialog):
         if self.fileBrowserOF.getFile():
             mp_path = self.fileBrowserOF.getPaths()[0]
             try:
-                mp = kp.load(mp_path, lazy=True)
+                mp = kp.load(mp_path)
                 if not len(mp.phase.name):
                     mp.phase.name = path.basename(
                         path.dirname(mp_path)

--- a/setup_script.iss
+++ b/setup_script.iss
@@ -6,7 +6,7 @@
 #define MyAppPublisher "EBSP Indexer Developers"
 #define MyAppExeName "EBSP Indexer.exe"
 
-#define InstallerVersion "0.0.3"
+#define InstallerVersion "0.0.5"
 
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application. Do not use the same AppId value in installers for other applications.


### PR DESCRIPTION
Knowns Issues
- Refinement of orientations of a crystal map which includes not_indexed points, might produce results that cannot be opened in signal navigation.  
- Pattern Selection currently requires lazy loading and will therefore not be affected by turning lazy loading off in the settings.