### PR TITLE
Small fix to DI and change to Settings dialog

### DIFF
--- a/scripts/advanced_settings.py
+++ b/scripts/advanced_settings.py
@@ -32,6 +32,7 @@ class AdvancedSettingsDialog(QDialog):
         self.ui.brukerButton.clicked.connect(lambda: self.setBruker())
         self.ui.tslButton.clicked.connect(lambda: self.setTSL())
         self.ui.lazyLoadingBox.clicked.connect(lambda: self.setLazy())
+        self.ui.checkBoxRefine.clicked.connect(lambda: self.setRefine())
         self.ui.savePcsBox.clicked.connect(lambda: self.setIndividualPCData())
         self.ui.buttonBox.accepted.connect(lambda: self.saveSettings())
         self.ui.directoryBox.clicked.connect(lambda: self.toggleDefaultDirectory())
@@ -93,6 +94,9 @@ class AdvancedSettingsDialog(QDialog):
         else:
             self.lazy = False
 
+    def setRefine(self):
+        self.refine = self.ui.checkBoxRefine.isChecked()
+
     def colorPicker(self):
         if self.ui.colorTreeWidget.currentItem().parent() is None:
             return
@@ -144,6 +148,16 @@ class AdvancedSettingsDialog(QDialog):
         else:
             self.lazy = False
 
+        try:
+            if self.setting_file.read("Refine orientations") == "True":
+                self.ui.checkBoxRefine.setChecked(True)
+                self.refine = True
+            else:
+                self.refine = False
+                
+        except:
+            self.refine = False
+
         if exists(self.setting_file.read("Default Directory")):
             self.ui.directoryBox.setChecked(True)
             self.directory = self.setting_file.read("Default Directory")
@@ -170,6 +184,7 @@ class AdvancedSettingsDialog(QDialog):
         self.setting_file.write("Individual PC data", str(self.individual_PC_data))
         self.setting_file.write("Convention", str(self.convention))
         self.setting_file.write("Lazy Loading", str(self.lazy))
+        self.setting_file.write("Refine orientations", str(self.refine))
         self.setting_file.write("Default Directory", str(self.directory))
         self.setting_file.write("Colors", json.dumps(self.colors))
         self.setting_file.save()

--- a/scripts/dictionary_indexing.py
+++ b/scripts/dictionary_indexing.py
@@ -114,6 +114,12 @@ class DiSetupDialog(QDialog):
 
         if self.program_settings.read("Lazy Loading") == "False":
             self.ui.checkBoxLazy.setChecked(False)
+        
+        try:
+            if self.program_settings.read("Refine orientations") == "True":
+                self.ui.checkBoxRefine.setChecked(True)
+        except:
+            pass
 
         # Update pattern center to be displayed in UI
         try:
@@ -402,7 +408,7 @@ class DiSetupDialog(QDialog):
                 file_mp,
                 energy=self.energy,  # single energies like 10, 11, 12 etc. or a range like (10, 20)
                 projection="lambert",  # stereographic, lambert
-                hemisphere="upper",  # upper, lower
+                hemisphere="both",  # upper, lower
                 lazy=True,
             )
             if mp.phase.name == "":

--- a/ui/advanced_settings.ui
+++ b/ui/advanced_settings.ui
@@ -27,7 +27,7 @@
    <item row="0" column="0">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="fileExplorerTab">
       <attribute name="title">
@@ -260,6 +260,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="checkBoxRefine">
+         <property name="text">
+          <string>Refine orientations</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QLabel" name="label_7">
          <property name="text">
           <string>Colors:</string>
@@ -297,6 +304,7 @@
          </property>
          <property name="font">
           <font>
+           <weight>50</weight>
            <bold>false</bold>
           </font>
          </property>

--- a/ui/di_setup.ui
+++ b/ui/di_setup.ui
@@ -587,7 +587,7 @@
                <string>Refine orientations</string>
               </property>
               <property name="checked">
-               <bool>true</bool>
+               <bool>false</bool>
               </property>
               <property name="tristate">
                <bool>false</bool>

--- a/ui/ui_advanced_settings.py
+++ b/ui/ui_advanced_settings.py
@@ -198,6 +198,11 @@ class Ui_AdvancedSettings(object):
 
         self.verticalLayout_4.addWidget(self.lazyLoadingBox)
 
+        self.checkBoxRefine = QCheckBox(self.indexingTab)
+        self.checkBoxRefine.setObjectName(u"checkBoxRefine")
+
+        self.verticalLayout_4.addWidget(self.checkBoxRefine)
+
         self.label_7 = QLabel(self.indexingTab)
         self.label_7.setObjectName(u"label_7")
 
@@ -285,7 +290,7 @@ class Ui_AdvancedSettings(object):
         self.buttonBox.accepted.connect(AdvancedSettings.accept)
         self.buttonBox.rejected.connect(AdvancedSettings.reject)
 
-        self.tabWidget.setCurrentIndex(0)
+        self.tabWidget.setCurrentIndex(2)
 
 
         QMetaObject.connectSlotsByName(AdvancedSettings)
@@ -313,6 +318,7 @@ class Ui_AdvancedSettings(object):
         self.tabWidget.setTabText(self.tabWidget.indexOf(self.preProcessingTab), QCoreApplication.translate("AdvancedSettings", u"Pre Prosessing", None))
         self.label.setText(QCoreApplication.translate("AdvancedSettings", u"Default settings:", None))
         self.lazyLoadingBox.setText(QCoreApplication.translate("AdvancedSettings", u"Lazy Loading (recommended)", None))
+        self.checkBoxRefine.setText(QCoreApplication.translate("AdvancedSettings", u"Refine orientations", None))
         self.label_7.setText(QCoreApplication.translate("AdvancedSettings", u"Colors:", None))
         ___qtreewidgetitem = self.colorTreeWidget.headerItem()
         ___qtreewidgetitem.setText(1, QCoreApplication.translate("AdvancedSettings", u"2", None));

--- a/ui/ui_di_setup.py
+++ b/ui/ui_di_setup.py
@@ -381,7 +381,7 @@ class Ui_DiSetupDialog(object):
         self.checkBoxRefine.setObjectName(u"checkBoxRefine")
         self.checkBoxRefine.setMinimumSize(QSize(200, 0))
         self.checkBoxRefine.setLayoutDirection(Qt.LeftToRight)
-        self.checkBoxRefine.setChecked(True)
+        self.checkBoxRefine.setChecked(False)
         self.checkBoxRefine.setTristate(False)
 
         self.verticalLayout.addWidget(self.checkBoxRefine)


### PR DESCRIPTION
- Refinement set to off by default. Default can be set in Settings.
- DI loads both hemispheres for master pattern to account for phases with no inversion symmetry